### PR TITLE
Recover managed account

### DIFF
--- a/node/api/recover.go
+++ b/node/api/recover.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -40,6 +41,11 @@ type AccountRecoveryResponse struct {
 func GetRecoveryCodeHandler(identityBackend storage.IdentityBackend) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		email := c.Query("email")
+
+		if strings.Contains(email, "@") {
+			// if the username is an email, transform to lower case
+			email = strings.ToLower(email)
+		}
 
 		acct, err := identityBackend.GetAccount(email)
 		if err != nil {
@@ -88,6 +94,11 @@ func RecoverAccountHandler(identityBackend storage.IdentityBackend) gin.HandlerF
 			log.Err(err).Str("body", string(buf)).Msg("Bad recover request body")
 			apibase.AbortWithError(c, http.StatusBadRequest, "Bad register request")
 			return
+		}
+
+		if strings.Contains(req.UserID, "@") {
+			// if the user id is an email, transform to lower case
+			req.UserID = strings.ToLower(req.UserID)
 		}
 
 		rc, err := identityBackend.GetRecoveryCode(req.RecoveryCode)

--- a/remote/caller/accounts.go
+++ b/remote/caller/accounts.go
@@ -229,7 +229,7 @@ func (c *MetaLockerHTTPCaller) GetAccountRecoveryCode(username string) (string, 
 
 func (c *MetaLockerHTTPCaller) RecoverAccount(userID string, privKey ed25519.PrivateKey, recoveryCode, newPassphrase string) (*account.Account, error) {
 
-	req := account.BuildRecoveryRequest(userID, recoveryCode, privKey, newPassphrase)
+	req := account.BuildRecoveryRequest(userID, recoveryCode, privKey, newPassphrase, nil)
 
 	res, err := c.client.SendRequest(http.MethodPost, "/v1/recover-account",
 		httpsecure.WithJSONBody(req),


### PR DESCRIPTION
This change enables change server side recovery for managed accounts for clients that don't have access to advanced cryptography.

The standard account recovery process enables the user to gain access to the account, if the recovery phrase is provided. Then the user would rebuild cryptographic material in the account on the client side, so that no secrets ever get exposed to the server.

In some cases, such as [Sequel](https://sequel.space), rebuilding crypto material in the web app is problematic. This PR offers a way to recover a managed account on the server side with just minimal crypto setup in the client. It's less secure, but managed accounts partially expose the secrets to the server side anyway, so it doesn't significantly impact safety of the account data.